### PR TITLE
Fix Russian typo in flash message

### DIFF
--- a/src/routes/main.rs
+++ b/src/routes/main.rs
@@ -129,7 +129,7 @@ pub async fn save_user(
             FlashMessage::success("Параметры изменены.".to_string()).send();
         }
         Err(err) => {
-            FlashMessage::error(format!("Ошибка при изменений параметров: {}", err)).send();
+            FlashMessage::error(format!("Ошибка при изменении параметров: {}", err)).send();
         }
     }
     redirect("/")


### PR DESCRIPTION
## Summary
- correct typo in user settings flash message

## Testing
- `cargo test` *(fails: failed to download from https://index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_686ad5431174832f95ed1653a3f493ba