### PR TITLE
Fix menu list filtering

### DIFF
--- a/src/repository/menu.rs
+++ b/src/repository/menu.rs
@@ -30,12 +30,14 @@ impl MenuRepository for DieselMenuRepository<'_> {
         Ok(menu)
     }
 
-    fn list(&self) -> RepositoryResult<Vec<Menu>> {
+    fn list(&self, hub_id: i32) -> RepositoryResult<Vec<Menu>> {
         use crate::schema::menu;
 
         let mut connection = self.pool.get()?;
 
-        let results = menu::table.load::<DbMenu>(&mut connection)?;
+        let results = menu::table
+            .filter(menu::hub_id.eq(hub_id))
+            .load::<DbMenu>(&mut connection)?;
 
         Ok(results.into_iter().map(|db_menu| db_menu.into()).collect()) // Convert DbMenu to DomainMenu
     }

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -51,6 +51,6 @@ pub trait MenuRepository {
         &self,
         new_menu: &crate::domain::menu::NewMenu,
     ) -> RepositoryResult<crate::domain::menu::Menu>;
-    fn list(&self) -> RepositoryResult<Vec<crate::domain::menu::Menu>>;
+    fn list(&self, hub_id: i32) -> RepositoryResult<Vec<crate::domain::menu::Menu>>;
     fn delete(&self, menu_id: i32) -> RepositoryResult<usize>;
 }

--- a/src/routes/main.rs
+++ b/src/routes/main.rs
@@ -82,7 +82,7 @@ pub async fn index(
 
     let repo = DieselMenuRepository::new(&pool);
 
-    let menu = match repo.list() {
+    let menu = match repo.list(user.hub_id) {
         Ok(menu) => menu,
         Err(e) => {
             error!("Failed to list menu: {}", e);


### PR DESCRIPTION
## Summary
- filter the `list` query in `DieselMenuRepository` by hub ID
- update `MenuRepository` trait to take `hub_id`
- fetch menu items by hub in the main index route

## Testing
- `cargo test` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_686ad358b90c832f87319aea9a713e06