### PR TITLE
Add docstrings across modules

### DIFF
--- a/src/domain/hub.rs
+++ b/src/domain/hub.rs
@@ -2,6 +2,7 @@ use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+/// A business entity representing a hub which groups users and menus.
 pub struct Hub {
     pub id: i32,
     pub name: String,
@@ -10,6 +11,7 @@ pub struct Hub {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+/// Data used for creating a new [`Hub`].
 pub struct NewHub {
     pub name: String,
 }

--- a/src/domain/menu.rs
+++ b/src/domain/menu.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+/// A navigation item available to users of a [`Hub`].
 pub struct Menu {
     pub id: i32,
     pub name: String,
@@ -9,6 +10,7 @@ pub struct Menu {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+/// Parameters required to create a new [`Menu`].
 pub struct NewMenu {
     pub name: String,
     pub url: String,

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,3 +1,8 @@
+//! Domain data structures used throughout the application.
+//!
+//! These structs represent the business entities independent from any
+//! persistence or transport concerns.
+
 pub mod hub;
 pub mod role;
 pub mod user;

--- a/src/domain/role.rs
+++ b/src/domain/role.rs
@@ -2,6 +2,7 @@ use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+/// Role assigned to a user describing a set of permissions.
 pub struct Role {
     pub id: i32,
     pub name: String,
@@ -10,17 +11,20 @@ pub struct Role {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+/// Information required to create a new [`Role`].
 pub struct NewRole {
     pub name: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+/// Mapping table between users and roles.
 pub struct UserRole {
     pub user_id: i32,
     pub role_id: i32,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+/// New entry in the user/role mapping table.
 pub struct NewUserRole {
     pub user_id: i32,
     pub role_id: i32,

--- a/src/domain/user.rs
+++ b/src/domain/user.rs
@@ -2,6 +2,10 @@ use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+/// Representation of a user in the system.
+///
+/// This struct mirrors the data stored in the database but is free of any
+/// persistence related logic.
 pub struct User {
     pub id: i32,
     pub email: String,
@@ -13,6 +17,7 @@ pub struct User {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+/// Data required to create a new user.
 pub struct NewUser {
     pub email: String,
     pub name: Option<String>,
@@ -21,6 +26,7 @@ pub struct NewUser {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+/// Optional fields that can be updated for a user.
 pub struct UpdateUser {
     pub name: Option<String>,
     pub password: Option<String>,

--- a/src/forms/auth.rs
+++ b/src/forms/auth.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 use crate::domain::user::NewUser as DomainNewUser;
 
 #[derive(Deserialize)]
+/// Form data submitted when a user logs in.
 pub struct LoginForm {
     pub email: String,
     pub password: String,
@@ -10,6 +11,7 @@ pub struct LoginForm {
 }
 
 #[derive(Deserialize)]
+/// Form data used during user registration.
 pub struct RegisterForm {
     pub email: String,
     pub password: String,

--- a/src/forms/main.rs
+++ b/src/forms/main.rs
@@ -6,6 +6,7 @@ use crate::domain::{
 };
 
 #[derive(Deserialize)]
+/// Form used on the profile page to update the current user.
 pub struct SaveUserForm {
     pub name: Option<String>,
     pub password: Option<String>,
@@ -21,6 +22,7 @@ impl From<SaveUserForm> for DomainUpdateUser {
 }
 
 #[derive(Deserialize)]
+/// Request payload for creating a new role via the admin interface.
 pub struct AddRoleForm {
     pub name: String,
 }
@@ -32,6 +34,7 @@ impl From<AddRoleForm> for DomainNewRole {
 }
 
 #[derive(Deserialize)]
+/// Full user editing form used by administrators.
 pub struct UpdateUserForm {
     pub id: i32,
     pub name: Option<String>,
@@ -50,6 +53,7 @@ impl From<UpdateUserForm> for DomainUpdateUser {
 }
 
 #[derive(Deserialize)]
+/// Parameters for adding a new hub.
 pub struct AddHubForm {
     pub name: String,
 }
@@ -61,6 +65,7 @@ impl From<AddHubForm> for DomainNewHub {
 }
 
 #[derive(Deserialize)]
+/// Payload for adding a menu entry to a hub.
 pub struct AddMenuForm {
     pub name: String,
     pub url: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+//! Main library crate for the Pushkind authentication service.
+//!
+//! This crate exposes the domain models, database access layer and HTTP
+//! handlers that make up the application. It is used by `main.rs` to build
+//! the Actix-Web application and can also be reused for integration tests.
+
 pub mod db;
 pub mod domain;
 pub mod forms;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+//! Application entry point building the Actix-Web server.
+
 use std::env;
 
 use actix_identity::IdentityMiddleware;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,3 +1,9 @@
+//! Custom middleware used by the HTTP server.
+//!
+//! The [`RedirectUnauthorized`] middleware intercepts unauthorized responses
+//! and redirects the user to the sign in page instead of returning a bare
+//! `401` status code.
+
 use actix_web::{
     Error, HttpResponse,
     body::EitherBody,
@@ -7,6 +13,7 @@ use actix_web::{
 use futures_util::future::LocalBoxFuture;
 use std::future::{Ready, ready};
 
+/// Middleware factory that produces [`RedirectUnauthorizedMiddleware`].
 pub struct RedirectUnauthorized;
 
 impl<S, B> Transform<S, ServiceRequest> for RedirectUnauthorized
@@ -26,6 +33,7 @@ where
     }
 }
 
+/// Inner service used by [`RedirectUnauthorized`].
 pub struct RedirectUnauthorizedMiddleware<S> {
     service: S,
 }

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -1,4 +1,5 @@
 #[derive(Clone)]
+/// Basic configuration shared across handlers.
 pub struct ServerConfig {
     pub secret: String,
 }

--- a/src/models/hub.rs
+++ b/src/models/hub.rs
@@ -5,6 +5,7 @@ use crate::domain::{hub::Hub as DomainHub, hub::NewHub as DomainNewHub};
 
 #[derive(Debug, Clone, Identifiable, Queryable)]
 #[diesel(table_name = crate::schema::hubs)]
+/// Database representation of a [`crate::domain::hub::Hub`].
 pub struct Hub {
     pub id: i32,
     pub name: String,
@@ -14,6 +15,7 @@ pub struct Hub {
 
 #[derive(Insertable)]
 #[diesel(table_name = crate::schema::hubs)]
+/// Insertable form of [`Hub`].
 pub struct NewHub<'a> {
     pub name: &'a str,
 }

--- a/src/models/menu.rs
+++ b/src/models/menu.rs
@@ -6,6 +6,7 @@ use crate::models::hub::Hub;
 #[derive(Debug, Clone, Identifiable, Associations, Queryable)]
 #[diesel(belongs_to(Hub, foreign_key=hub_id))]
 #[diesel(table_name = crate::schema::menu)]
+/// Database model for [`crate::domain::menu::Menu`].
 pub struct Menu {
     pub id: i32,
     pub name: String,
@@ -15,6 +16,7 @@ pub struct Menu {
 
 #[derive(Insertable)]
 #[diesel(table_name = crate::schema::menu)]
+/// Insertable variant of [`Menu`].
 pub struct NewMenu<'a> {
     pub name: &'a str,
     pub url: &'a str,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,8 @@
+//! Database models used by Diesel.
+//!
+//! These types closely mirror the schema of the database and are used by the
+//! repository layer. They also implement conversions to the domain layer types.
+
 pub mod auth;
 pub mod config;
 pub mod hub;

--- a/src/models/role.rs
+++ b/src/models/role.rs
@@ -7,6 +7,7 @@ use crate::models::user::User;
 
 #[derive(Debug, Clone, Identifiable, Queryable)]
 #[diesel(table_name = crate::schema::roles)]
+/// Diesel model for [`crate::domain::role::Role`].
 pub struct Role {
     pub id: i32,
     pub name: String,
@@ -16,6 +17,7 @@ pub struct Role {
 
 #[derive(Insertable)]
 #[diesel(table_name = crate::schema::roles)]
+/// Insertable form of [`Role`].
 pub struct NewRole<'a> {
     pub name: &'a str,
 }
@@ -25,6 +27,7 @@ pub struct NewRole<'a> {
 #[diesel(belongs_to(User, foreign_key=user_id))]
 #[diesel(belongs_to(Role, foreign_key=role_id))]
 #[diesel(table_name = crate::schema::user_roles)]
+/// Association table linking users to roles.
 pub struct UserRole {
     pub user_id: i32,
     pub role_id: i32,
@@ -32,6 +35,7 @@ pub struct UserRole {
 
 #[derive(Insertable)]
 #[diesel(table_name = crate::schema::user_roles)]
+/// Insertable variant of [`UserRole`].
 pub struct NewUserRole {
     pub user_id: i32,
     pub role_id: i32,

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -8,6 +8,7 @@ use crate::models::hub::Hub;
 #[derive(Debug, Clone, Identifiable, Associations, Queryable)]
 #[diesel(belongs_to(Hub, foreign_key=hub_id))]
 #[diesel(table_name = crate::schema::users)]
+/// Diesel model for [`crate::domain::user::User`].
 pub struct User {
     pub id: i32,
     pub email: String,
@@ -20,6 +21,7 @@ pub struct User {
 
 #[derive(Insertable)]
 #[diesel(table_name = crate::schema::users)]
+/// Insertable form of [`User`].
 pub struct NewUser<'a> {
     pub email: &'a str,
     pub name: Option<&'a str>,
@@ -29,6 +31,7 @@ pub struct NewUser<'a> {
 
 #[derive(AsChangeset)]
 #[diesel(table_name = crate::schema::users)]
+/// Data used when updating a [`User`] record.
 pub struct UpdateUser<'a> {
     pub name: Option<&'a str>,
     pub password_hash: String,

--- a/src/repository/errors.rs
+++ b/src/repository/errors.rs
@@ -1,9 +1,12 @@
+//! Error types returned by repository implementations.
+
 use bcrypt::BcryptError;
 use diesel::r2d2::{Error as R2D2Error, PoolError};
 use diesel::result::{DatabaseErrorKind, Error as DieselError};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+/// Common errors returned by repository methods.
 pub enum RepositoryError {
     #[error("Entity not found")]
     NotFound,

--- a/src/repository/hub.rs
+++ b/src/repository/hub.rs
@@ -6,6 +6,7 @@ use crate::models::hub::{Hub as DbHub, NewHub as NewDbHub};
 use crate::repository::HubRepository;
 use crate::repository::errors::RepositoryResult;
 
+/// Diesel implementation of [`HubRepository`].
 pub struct DieselHubRepository<'a> {
     pub pool: &'a DbPool,
 }

--- a/src/repository/menu.rs
+++ b/src/repository/menu.rs
@@ -6,6 +6,7 @@ use crate::models::menu::{Menu as DbMenu, NewMenu as NewDbMenu};
 use crate::repository::MenuRepository;
 use crate::repository::errors::RepositoryResult;
 
+/// Diesel implementation of [`MenuRepository`].
 pub struct DieselMenuRepository<'a> {
     pub pool: &'a DbPool,
 }

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -1,3 +1,9 @@
+//! Abstractions over data persistence.
+//!
+//! Traits defined in this module describe the operations that can be performed
+//! on the underlying storage. Diesel based implementations live in the
+//! submodules.
+
 pub mod errors;
 pub mod hub;
 pub mod menu;

--- a/src/repository/role.rs
+++ b/src/repository/role.rs
@@ -6,6 +6,7 @@ use crate::models::role::{NewRole as NewDbRole, Role as DbRole};
 use crate::repository::RoleRepository;
 use crate::repository::errors::RepositoryResult;
 
+/// Diesel implementation of [`RoleRepository`].
 pub struct DieselRoleRepository<'a> {
     pub pool: &'a DbPool,
 }

--- a/src/repository/user.rs
+++ b/src/repository/user.rs
@@ -9,6 +9,7 @@ use crate::models::user::{NewUser as NewDbUser, UpdateUser as DbUpdateUser, User
 use crate::repository::UserRepository;
 use crate::repository::errors::{RepositoryError, RepositoryResult};
 
+/// Diesel implementation of [`UserRepository`].
 pub struct DieselUserRepository<'a> {
     pub pool: &'a DbPool,
 }

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -1,3 +1,5 @@
+//! Administrative endpoints used to manage users, roles and hubs.
+
 use actix_web::{HttpResponse, Responder, post, web};
 use actix_web_flash_messages::FlashMessage;
 use log::error;

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -1,3 +1,5 @@
+//! Authentication and session management endpoints.
+
 use actix_identity::Identity;
 use actix_web::{HttpMessage, HttpRequest, HttpResponse};
 use actix_web::{Responder, get, post, web};

--- a/src/routes/main.rs
+++ b/src/routes/main.rs
@@ -1,3 +1,5 @@
+//! General site routes and small API endpoints.
+
 use actix_web::{HttpResponse, Responder, get, post, web};
 use actix_web_flash_messages::{FlashMessage, IncomingFlashMessages};
 use log::error;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,3 +1,5 @@
+//! HTTP handlers and helpers.
+
 use actix_web::HttpResponse;
 use actix_web::http::header;
 use actix_web_flash_messages::{FlashMessage, Level};

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,9 +1,12 @@
+//! Helpers for integration tests.
+
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 
 use pushkind_auth::db::{DbPool, establish_connection_pool};
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!(); // assumes migrations/ exists
 
+/// Temporary database used in integration tests.
 pub struct TestDb {
     filename: String,
     pool: DbPool,


### PR DESCRIPTION
## Summary
- document most public modules and data structures
- give context for integration test helpers

## Testing
- `cargo test` *(fails: could not compile `pushkind-auth`)*

------
https://chatgpt.com/codex/tasks/task_e_686b67af9470832fa8515678aed4f9ce