### PR TITLE
Add tests for form conversions

### DIFF
--- a/tests/forms.rs
+++ b/tests/forms.rs
@@ -1,0 +1,72 @@
+use pushkind_auth::forms::auth::RegisterForm;
+use pushkind_auth::forms::main::{AddHubForm, AddRoleForm, SaveUserForm, UpdateUserForm};
+use pushkind_auth::domain::user::NewUser as DomainNewUser;
+use pushkind_auth::domain::user::UpdateUser as DomainUpdateUser;
+use pushkind_auth::domain::role::NewRole as DomainNewRole;
+use pushkind_auth::domain::hub::NewHub as DomainNewHub;
+
+#[test]
+fn test_register_form_into_domain_new_user() {
+    let form = RegisterForm {
+        email: "test@example.com".to_string(),
+        password: "secret".to_string(),
+        hub_id: 7,
+    };
+
+    let user: DomainNewUser = form.into();
+
+    assert_eq!(user.email, "test@example.com");
+    assert_eq!(user.password, "secret");
+    assert_eq!(user.hub_id, 7);
+    assert_eq!(user.name, None);
+}
+
+#[test]
+fn test_save_user_form_into_domain_update_user() {
+    let form = SaveUserForm {
+        name: Some("Alice".to_string()),
+        password: Some("password".to_string()),
+    };
+
+    let update: DomainUpdateUser = form.into();
+
+    assert_eq!(update.name, Some("Alice".to_string()));
+    assert_eq!(update.password, Some("password".to_string()));
+}
+
+#[test]
+fn test_add_role_form_into_domain_new_role() {
+    let form = AddRoleForm {
+        name: "editor".to_string(),
+    };
+
+    let role: DomainNewRole = form.into();
+
+    assert_eq!(role.name, "editor");
+}
+
+#[test]
+fn test_update_user_form_into_domain_update_user() {
+    let form = UpdateUserForm {
+        id: 1,
+        name: Some("Bob".to_string()),
+        password: Some("pwd".to_string()),
+        roles: vec![1, 2],
+    };
+
+    let update: DomainUpdateUser = form.into();
+
+    assert_eq!(update.name, Some("Bob".to_string()));
+    assert_eq!(update.password, Some("pwd".to_string()));
+}
+
+#[test]
+fn test_add_hub_form_into_domain_new_hub() {
+    let form = AddHubForm {
+        name: "My Hub".to_string(),
+    };
+
+    let hub: DomainNewHub = form.into();
+
+    assert_eq!(hub.name, "My Hub");
+}

--- a/tests/repository.rs
+++ b/tests/repository.rs
@@ -46,12 +46,12 @@ fn test_hub_repository_crud() {
         hub_id: hub.id,
     };
     menu_repo.create(&new_menu).unwrap();
-    assert_eq!(menu_repo.list().unwrap().len(), 1);
+    assert_eq!(menu_repo.list(hub.id).unwrap().len(), 1);
 
     repo.delete(hub.id).unwrap();
 
     // menus should be removed when hub is deleted
-    assert!(menu_repo.list().unwrap().is_empty());
+    assert!(menu_repo.list(hub.id).unwrap().is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add tests for conversions from form structs to domain types
- pass hub id to menu repository in tests

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686b6c6c6cd4832fb1f12084c3aa8d81