### PR TITLE
Add test for user model conversion

### DIFF
--- a/tests/models_user.rs
+++ b/tests/models_user.rs
@@ -1,0 +1,20 @@
+use bcrypt::verify;
+use pushkind_auth::domain::user::NewUser as DomainNewUser;
+use pushkind_auth::models::user::NewUser;
+
+#[test]
+fn test_new_user_try_from() {
+    let domain = DomainNewUser {
+        email: "john@example.com".to_string(),
+        name: Some("John Doe".to_string()),
+        hub_id: 5,
+        password: "super_secret".to_string(),
+    };
+
+    let db_user = NewUser::try_from(&domain).expect("conversion failed");
+
+    assert_eq!(db_user.email, domain.email);
+    assert_eq!(db_user.name, domain.name.as_deref());
+    assert_eq!(db_user.hub_id, domain.hub_id);
+    assert!(verify(&domain.password, &db_user.password_hash).unwrap());
+}


### PR DESCRIPTION
## Summary
- add a new integration test covering `NewUser::try_from`

## Testing
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_686b6e72aa04832f916a6b5baecf789d