### PR TITLE
Add unit tests for routes helpers

### DIFF
--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -22,7 +22,7 @@ struct AuthQueryParams {
     next: Option<String>,
 }
 
-fn get_success_and_failure_redirects(base_url: &str, next: Option<&str>) -> (String, String) {
+pub fn get_success_and_failure_redirects(base_url: &str, next: Option<&str>) -> (String, String) {
     let success_redirect_url = match next {
         Some(s) if !s.is_empty() => s.to_string(),
         _ => "/".to_string(),

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -25,7 +25,7 @@ lazy_static! {
     };
 }
 
-fn alert_level_to_str(level: &Level) -> &'static str {
+pub fn alert_level_to_str(level: &Level) -> &'static str {
     match level {
         Level::Error => "danger",
         Level::Warning => "warning",

--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -1,0 +1,34 @@
+use pushkind_auth::routes::auth::get_success_and_failure_redirects;
+use pushkind_auth::routes::alert_level_to_str;
+use actix_web_flash_messages::Level;
+
+#[test]
+fn test_get_success_and_failure_redirects_with_next() {
+    let (success, failure) = get_success_and_failure_redirects("/auth/signin", Some("/dashboard"));
+    assert_eq!(success, "/dashboard");
+    assert_eq!(failure, "/auth/signin?next=/dashboard");
+}
+
+#[test]
+fn test_get_success_and_failure_redirects_without_next() {
+    let (success, failure) = get_success_and_failure_redirects("/auth/signup", None);
+    assert_eq!(success, "/");
+    assert_eq!(failure, "/auth/signup");
+}
+
+#[test]
+fn test_get_success_and_failure_redirects_with_empty_next() {
+    let (success, failure) = get_success_and_failure_redirects("/auth/signin", Some(""));
+    assert_eq!(success, "/");
+    assert_eq!(failure, "/auth/signin");
+}
+
+#[test]
+fn test_alert_level_to_str_mappings() {
+    assert_eq!(alert_level_to_str(&Level::Error), "danger");
+    assert_eq!(alert_level_to_str(&Level::Warning), "warning");
+    assert_eq!(alert_level_to_str(&Level::Success), "success");
+    assert_eq!(alert_level_to_str(&Level::Info), "info");
+    assert_eq!(alert_level_to_str(&Level::Debug), "info");
+}
+


### PR DESCRIPTION
## Summary
- test `get_success_and_failure_redirects`
- test `alert_level_to_str`
- expose helper functions for tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686b72ca90b4832f8b0d00b04204e4c4