### PR TITLE
Add redirect middleware tests

### DIFF
--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -1,0 +1,32 @@
+use actix_web::{http::{header, StatusCode}, test, web, App, HttpResponse};
+
+use pushkind_auth::middleware::RedirectUnauthorized;
+
+#[actix_web::test]
+async fn redirects_unauthorized_to_signin() {
+    let app = test::init_service(
+        App::new()
+            .wrap(RedirectUnauthorized)
+            .default_service(web::to(|| async { HttpResponse::Unauthorized().finish() }))
+    ).await;
+
+    let req = test::TestRequest::default().to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    assert_eq!(resp.headers().get(header::LOCATION).unwrap(), "/auth/signin");
+}
+
+#[actix_web::test]
+async fn success_response_passes_through() {
+    let app = test::init_service(
+        App::new()
+            .wrap(RedirectUnauthorized)
+            .default_service(web::to(|| async { HttpResponse::Ok().finish() }))
+    ).await;
+
+    let req = test::TestRequest::default().to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}


### PR DESCRIPTION
## Summary
- add middleware tests covering `RedirectUnauthorized`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686b75e27788832f9abb646115c610a7