### PR TITLE
Fix updating timestamp for user

### DIFF
--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -35,6 +35,7 @@ pub struct NewUser {
 pub struct UpdateUser<'a> {
     pub name: Option<&'a str>,
     pub password_hash: String,
+    pub updated_at: NaiveDateTime,
 }
 
 impl From<User> for DomainUser {

--- a/src/repository/user.rs
+++ b/src/repository/user.rs
@@ -1,5 +1,6 @@
 use bcrypt::{DEFAULT_COST, hash, verify};
 use diesel::prelude::*;
+use chrono::Utc;
 
 use crate::db::{DbPool, lower, lower_nullable};
 use crate::domain::role::Role;
@@ -131,6 +132,7 @@ impl UserRepository for DieselUserRepository<'_> {
         let db_updates = DbUpdateUser {
             name: updates.name,
             password_hash,
+            updated_at: Utc::now().naive_utc(),
         };
 
         let user = diesel::update(users::table)

--- a/tests/repository.rs
+++ b/tests/repository.rs
@@ -79,6 +79,8 @@ fn test_user_repository_crud() {
     let user = repo.create(new_user).unwrap();
     assert_eq!(user.name, Some("TestUser".to_string()));
     assert_eq!(user.email, "test@test.test");
+    let created_at = user.created_at;
+    let original_updated_at = user.updated_at;
 
     let inserted = repo.assign_roles(user.id, &[role.id]).unwrap();
     assert!(inserted == 1);
@@ -114,6 +116,8 @@ fn test_user_repository_crud() {
         .unwrap();
     assert_eq!(user.name, Some("new name".to_string()));
     assert!(repo.verify_password("new password", &user.password_hash));
+    assert!(user.updated_at > original_updated_at);
+    assert_eq!(user.created_at, created_at);
 
     repo.assign_roles(user.id, &[]).unwrap();
 


### PR DESCRIPTION
## Summary
- ensure `updated_at` column is set when updating users
- verify timestamp update in repository tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686fa1eab268832fac6caaba1162cc6d