### PR TITLE
Refactor API routes into separate scope

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 use std::env;
 
+use actix_cors::Cors;
 use actix_identity::IdentityMiddleware;
 use actix_session::{SessionMiddleware, storage::CookieSessionStore};
 use actix_web::cookie::Key;
@@ -9,7 +10,6 @@ use actix_web::{App, HttpServer, middleware, web};
 use actix_web_flash_messages::{FlashMessagesFramework, storage::CookieMessageStore};
 use dotenvy::dotenv;
 use log::error;
-use actix_cors::Cors;
 
 use pushkind_auth::db::establish_connection_pool;
 use pushkind_auth::middleware::RedirectUnauthorized;
@@ -18,8 +18,9 @@ use pushkind_auth::routes::admin::{
     add_hub, add_menu, add_role, delete_hub, delete_menu, delete_role, delete_user, update_user,
     user_modal,
 };
+use pushkind_auth::routes::api::{api_v1_id, api_v1_users};
 use pushkind_auth::routes::auth::{login, logout, register, signin, signup};
-use pushkind_auth::routes::main::{api_v1_id, api_v1_users, index, save_user};
+use pushkind_auth::routes::main::{index, save_user};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -89,13 +90,12 @@ async fn main() -> std::io::Result<()> {
                     .service(add_menu)
                     .service(delete_menu),
             )
+            .service(web::scope("/api").service(api_v1_id).service(api_v1_users))
             .service(
                 web::scope("")
                     .wrap(RedirectUnauthorized)
                     .service(index)
-                    .service(save_user)
-                    .service(api_v1_id)
-                    .service(api_v1_users),
+                    .service(save_user),
             )
             .app_data(web::Data::new(pool.clone()))
             .app_data(web::Data::new(server_config.clone()))

--- a/src/routes/api.rs
+++ b/src/routes/api.rs
@@ -1,0 +1,65 @@
+use actix_web::{HttpResponse, Responder, get, web};
+use log::error;
+use serde::Deserialize;
+
+use crate::db::DbPool;
+use crate::models::auth::AuthenticatedUser;
+use crate::repository::UserRepository;
+use crate::repository::user::DieselUserRepository;
+
+#[derive(Deserialize)]
+struct ApiV1IdParams {
+    id: Option<i32>,
+}
+
+#[get("/v1/id")]
+pub async fn api_v1_id(
+    params: web::Query<ApiV1IdParams>,
+    user: AuthenticatedUser,
+    pool: web::Data<DbPool>,
+) -> impl Responder {
+    match params.id {
+        Some(id) => {
+            let repo = DieselUserRepository::new(&pool);
+            match repo.get_by_id(id) {
+                Ok(Some(found_user)) if user.hub_id == found_user.hub_id => {
+                    HttpResponse::Ok().json(AuthenticatedUser::from(found_user))
+                }
+                Err(e) => {
+                    error!("Failed to get user: {e}");
+                    HttpResponse::InternalServerError().finish()
+                }
+                _ => HttpResponse::NotFound().finish(),
+            }
+        }
+        None => HttpResponse::Ok().json(user),
+    }
+}
+
+#[derive(Deserialize)]
+struct ApiV1UsersQueryParams {
+    role: String,
+    query: String,
+}
+
+#[get("/v1/users")]
+pub async fn api_v1_users(
+    params: web::Query<ApiV1UsersQueryParams>,
+    user: AuthenticatedUser,
+    pool: web::Data<DbPool>,
+) -> impl Responder {
+    let repo = DieselUserRepository::new(&pool);
+
+    match repo.search(user.hub_id, &params.role, &params.query) {
+        Ok(users) => {
+            let users: Vec<AuthenticatedUser> =
+                users.into_iter().map(AuthenticatedUser::from).collect();
+
+            HttpResponse::Ok().json(users)
+        }
+        Err(e) => {
+            error!("Failed to list users: {e}");
+            HttpResponse::InternalServerError().finish()
+        }
+    }
+}

--- a/src/routes/main.rs
+++ b/src/routes/main.rs
@@ -3,7 +3,6 @@
 use actix_web::{HttpResponse, Responder, get, post, web};
 use actix_web_flash_messages::{FlashMessage, IncomingFlashMessages};
 use log::error;
-use serde::Deserialize;
 use tera::Context;
 
 use crate::db::DbPool;
@@ -136,61 +135,4 @@ pub async fn save_user(
         }
     }
     redirect("/")
-}
-
-#[derive(Deserialize)]
-struct ApiV1IdParams {
-    id: Option<i32>,
-}
-
-#[get("/api/v1/id")]
-pub async fn api_v1_id(
-    params: web::Query<ApiV1IdParams>,
-    user: AuthenticatedUser,
-    pool: web::Data<DbPool>,
-) -> impl Responder {
-    match params.id {
-        Some(id) => {
-            let repo = DieselUserRepository::new(&pool);
-            match repo.get_by_id(id) {
-                Ok(Some(found_user)) if user.hub_id == found_user.hub_id => {
-                    HttpResponse::Ok().json(AuthenticatedUser::from(found_user))
-                }
-                Err(e) => {
-                    error!("Failed to get user: {e}");
-                    HttpResponse::InternalServerError().finish()
-                }
-                _ => HttpResponse::NotFound().finish(),
-            }
-        }
-        None => HttpResponse::Ok().json(user),
-    }
-}
-
-#[derive(Deserialize)]
-struct ApiV1UsersQueryParams {
-    role: String,
-    query: String,
-}
-
-#[get("/api/v1/users")]
-pub async fn api_v1_users(
-    params: web::Query<ApiV1UsersQueryParams>,
-    user: AuthenticatedUser,
-    pool: web::Data<DbPool>,
-) -> impl Responder {
-    let repo = DieselUserRepository::new(&pool);
-
-    match repo.search(user.hub_id, &params.role, &params.query) {
-        Ok(users) => {
-            let users: Vec<AuthenticatedUser> =
-                users.into_iter().map(AuthenticatedUser::from).collect();
-
-            HttpResponse::Ok().json(users)
-        }
-        Err(e) => {
-            error!("Failed to list users: {e}");
-            HttpResponse::InternalServerError().finish()
-        }
-    }
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -10,6 +10,7 @@ use tera::{Context, Tera};
 use crate::models::auth::AuthenticatedUser;
 
 pub mod admin;
+pub mod api;
 pub mod auth;
 pub mod main;
 


### PR DESCRIPTION
## Summary
- move API endpoints out of main routes into `api.rs`
- expose new module from `routes`
- register API endpoints under `/api` scope without `RedirectUnauthorized`
- adjust imports

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687238b8bcd0832f879a826e3d4b3d3b