### PR TITLE
Refactor menu repository

### DIFF
--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -54,8 +54,14 @@ pub trait RoleRepository {
     fn delete(&self, role_id: i32) -> RepositoryResult<usize>;
 }
 
-pub trait MenuRepository {
-    fn create(&self, new_menu: &NewMenu) -> RepositoryResult<Menu>;
+pub trait MenuReader {
     fn list(&self, hub_id: i32) -> RepositoryResult<Vec<Menu>>;
+}
+
+pub trait MenuWriter {
+    fn create(&self, new_menu: &NewMenu) -> RepositoryResult<Menu>;
     fn delete(&self, menu_id: i32) -> RepositoryResult<usize>;
 }
+
+/// Backwards compatibility alias combining [`MenuReader`] and [`MenuWriter`].
+pub trait MenuRepository: MenuReader + MenuWriter {}

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -15,7 +15,7 @@ use crate::repository::hub::DieselHubRepository;
 use crate::repository::menu::DieselMenuRepository;
 use crate::repository::role::DieselRoleRepository;
 use crate::repository::user::DieselUserRepository;
-use crate::repository::{HubRepository, MenuRepository, RoleRepository, UserRepository};
+use crate::repository::{HubRepository, MenuWriter, RoleRepository, UserRepository};
 use crate::routes::{ensure_role, redirect, render_template};
 
 #[post("/role/add")]

--- a/src/routes/main.rs
+++ b/src/routes/main.rs
@@ -12,7 +12,7 @@ use crate::repository::hub::DieselHubRepository;
 use crate::repository::menu::DieselMenuRepository;
 use crate::repository::role::DieselRoleRepository;
 use crate::repository::user::DieselUserRepository;
-use crate::repository::{HubRepository, MenuRepository, RoleRepository, UserRepository};
+use crate::repository::{HubRepository, MenuReader, RoleRepository, UserRepository};
 use crate::routes::{alert_level_to_str, redirect, render_template};
 
 #[get("/")]

--- a/tests/repository.rs
+++ b/tests/repository.rs
@@ -4,7 +4,7 @@ use pushkind_auth::domain::role::NewRole;
 use pushkind_auth::domain::user::NewUser;
 use pushkind_auth::domain::user::UpdateUser;
 use pushkind_auth::repository::HubRepository;
-use pushkind_auth::repository::MenuRepository;
+use pushkind_auth::repository::{MenuReader, MenuWriter};
 use pushkind_auth::repository::RoleRepository;
 use pushkind_auth::repository::UserRepository;
 use pushkind_auth::repository::hub::DieselHubRepository;


### PR DESCRIPTION
## Summary
- split `MenuRepository` into reader/writer traits
- implement reader and writer for `DieselMenuRepository`
- update imports to use new traits

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6877778faa0c832fabe536510ced4023