### PR TITLE
Introduce separate role reader/writer traits

### DIFF
--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -46,13 +46,21 @@ pub trait HubRepository {
     fn delete(&self, hub_id: i32) -> RepositoryResult<usize>;
 }
 
-pub trait RoleRepository {
+pub trait RoleReader {
     fn get_by_id(&self, id: i32) -> RepositoryResult<Option<Role>>;
     fn get_by_name(&self, name: &str) -> RepositoryResult<Option<Role>>;
-    fn create(&self, new_role: &NewRole) -> RepositoryResult<Role>;
     fn list(&self) -> RepositoryResult<Vec<Role>>;
+}
+
+pub trait RoleWriter {
+    fn create(&self, new_role: &NewRole) -> RepositoryResult<Role>;
     fn delete(&self, role_id: i32) -> RepositoryResult<usize>;
 }
+
+/// Convenience trait combining [`RoleReader`] and [`RoleWriter`].
+pub trait RoleRepository: RoleReader + RoleWriter {}
+
+impl<T> RoleRepository for T where T: RoleReader + RoleWriter {}
 
 pub trait MenuRepository {
     fn create(&self, new_menu: &NewMenu) -> RepositoryResult<Menu>;

--- a/src/repository/role.rs
+++ b/src/repository/role.rs
@@ -3,10 +3,10 @@ use diesel::prelude::*;
 use crate::db::DbPool;
 use crate::domain::role::{NewRole, Role};
 use crate::models::role::{NewRole as NewDbRole, Role as DbRole};
-use crate::repository::RoleRepository;
 use crate::repository::errors::RepositoryResult;
+use crate::repository::{RoleReader, RoleWriter};
 
-/// Diesel implementation of [`RoleRepository`].
+/// Diesel implementation of [`RoleReader`] and [`RoleWriter`].
 pub struct DieselRoleRepository<'a> {
     pool: &'a DbPool,
 }
@@ -17,7 +17,7 @@ impl<'a> DieselRoleRepository<'a> {
     }
 }
 
-impl RoleRepository for DieselRoleRepository<'_> {
+impl RoleReader for DieselRoleRepository<'_> {
     fn get_by_id(&self, id: i32) -> RepositoryResult<Option<Role>> {
         use crate::schema::roles;
 
@@ -44,6 +44,18 @@ impl RoleRepository for DieselRoleRepository<'_> {
         Ok(result.map(|db_role| db_role.into())) // Convert DbRole to DomainRole
     }
 
+    fn list(&self) -> RepositoryResult<Vec<Role>> {
+        use crate::schema::roles;
+
+        let mut connection = self.pool.get()?;
+
+        let results = roles::table.load::<DbRole>(&mut connection)?;
+
+        Ok(results.into_iter().map(|db_role| db_role.into()).collect()) // Convert DbRole to DomainRole
+    }
+}
+
+impl RoleWriter for DieselRoleRepository<'_> {
     fn create(&self, new_role: &NewRole) -> RepositoryResult<Role> {
         use crate::schema::roles;
 
@@ -55,16 +67,6 @@ impl RoleRepository for DieselRoleRepository<'_> {
             .get_result::<DbRole>(&mut connection)
             .map(|db_role| db_role.into())?; // Convert DbRole to DomainRole
         Ok(role)
-    }
-
-    fn list(&self) -> RepositoryResult<Vec<Role>> {
-        use crate::schema::roles;
-
-        let mut connection = self.pool.get()?;
-
-        let results = roles::table.load::<DbRole>(&mut connection)?;
-
-        Ok(results.into_iter().map(|db_role| db_role.into()).collect()) // Convert DbRole to DomainRole
     }
 
     fn delete(&self, role_id: i32) -> RepositoryResult<usize> {

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -15,7 +15,7 @@ use crate::repository::hub::DieselHubRepository;
 use crate::repository::menu::DieselMenuRepository;
 use crate::repository::role::DieselRoleRepository;
 use crate::repository::user::DieselUserRepository;
-use crate::repository::{HubRepository, MenuRepository, RoleRepository, UserRepository};
+use crate::repository::{HubRepository, MenuRepository, RoleReader, RoleWriter, UserRepository};
 use crate::routes::{ensure_role, redirect, render_template};
 
 #[post("/role/add")]

--- a/src/routes/main.rs
+++ b/src/routes/main.rs
@@ -12,7 +12,7 @@ use crate::repository::hub::DieselHubRepository;
 use crate::repository::menu::DieselMenuRepository;
 use crate::repository::role::DieselRoleRepository;
 use crate::repository::user::DieselUserRepository;
-use crate::repository::{HubRepository, MenuRepository, RoleRepository, UserRepository};
+use crate::repository::{HubRepository, MenuRepository, RoleReader, UserRepository};
 use crate::routes::{alert_level_to_str, redirect, render_template};
 
 #[get("/")]

--- a/tests/repository.rs
+++ b/tests/repository.rs
@@ -5,12 +5,12 @@ use pushkind_auth::domain::user::NewUser;
 use pushkind_auth::domain::user::UpdateUser;
 use pushkind_auth::repository::HubRepository;
 use pushkind_auth::repository::MenuRepository;
-use pushkind_auth::repository::RoleRepository;
 use pushkind_auth::repository::UserRepository;
 use pushkind_auth::repository::hub::DieselHubRepository;
 use pushkind_auth::repository::menu::DieselMenuRepository;
 use pushkind_auth::repository::role::DieselRoleRepository;
 use pushkind_auth::repository::user::DieselUserRepository;
+use pushkind_auth::repository::{RoleReader, RoleWriter};
 
 mod common;
 


### PR DESCRIPTION
## Summary
- split `RoleRepository` into reader/writer traits
- implement `RoleReader` and `RoleWriter` for the Diesel repository
- update routes and tests to use the new traits

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68779adf4994832f90dd5880feab6a00