### PR TITLE
Refactor user repository traits

### DIFF
--- a/src/models/auth.rs
+++ b/src/models/auth.rs
@@ -12,7 +12,7 @@ use crate::db::DbPool;
 use crate::domain::role::Role;
 use crate::domain::user::User;
 use crate::models::config::ServerConfig;
-use crate::repository::UserRepository;
+use crate::repository::UserReader;
 use crate::repository::user::DieselUserRepository;
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -16,10 +16,9 @@ use crate::domain::role::{NewRole, Role};
 use crate::domain::user::{NewUser, UpdateUser, User};
 use crate::repository::errors::RepositoryResult;
 
-pub trait UserRepository {
+pub trait UserReader {
     fn get_by_id(&self, id: i32) -> RepositoryResult<Option<User>>;
     fn get_by_email(&self, email: &str, hub_id: i32) -> RepositoryResult<Option<User>>;
-    fn create(&self, new_user: &NewUser) -> RepositoryResult<User>;
     fn list(&self, hub_id: i32) -> RepositoryResult<Vec<(User, Vec<Role>)>>;
     fn verify_password(&self, password: &str, stored_hash: &str) -> bool;
     fn login(&self, email: &str, password: &str, hub_id: i32) -> RepositoryResult<Option<User>> {
@@ -32,11 +31,18 @@ pub trait UserRepository {
         Ok(None)
     }
     fn get_roles(&self, user_id: i32) -> RepositoryResult<Vec<Role>>;
+    fn search(&self, hub_id: i32, role: &str, query: &str) -> RepositoryResult<Vec<User>>;
+}
+
+pub trait UserWriter {
+    fn create(&self, new_user: &NewUser) -> RepositoryResult<User>;
     fn assign_roles(&self, user_id: i32, role_ids: &[i32]) -> RepositoryResult<usize>;
     fn update(&self, user_id: i32, updates: &UpdateUser) -> RepositoryResult<User>;
     fn delete(&self, user_id: i32) -> RepositoryResult<()>;
-    fn search(&self, hub_id: i32, role: &str, query: &str) -> RepositoryResult<Vec<User>>;
 }
+
+/// Convenience trait combining [`UserReader`] and [`UserWriter`].
+pub trait UserRepository: UserReader + UserWriter {}
 
 pub trait HubRepository {
     fn get_by_id(&self, id: i32) -> RepositoryResult<Option<Hub>>;

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -15,7 +15,7 @@ use crate::repository::hub::DieselHubRepository;
 use crate::repository::menu::DieselMenuRepository;
 use crate::repository::role::DieselRoleRepository;
 use crate::repository::user::DieselUserRepository;
-use crate::repository::{HubRepository, MenuRepository, RoleRepository, UserRepository};
+use crate::repository::{HubRepository, MenuRepository, RoleRepository, UserReader, UserWriter};
 use crate::routes::{ensure_role, redirect, render_template};
 
 #[post("/role/add")]

--- a/src/routes/api.rs
+++ b/src/routes/api.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 
 use crate::db::DbPool;
 use crate::models::auth::AuthenticatedUser;
-use crate::repository::UserRepository;
+use crate::repository::UserReader;
 use crate::repository::user::DieselUserRepository;
 
 #[derive(Deserialize)]

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -15,7 +15,7 @@ use crate::models::auth::AuthenticatedUser;
 use crate::models::config::ServerConfig;
 use crate::repository::hub::DieselHubRepository;
 use crate::repository::user::DieselUserRepository;
-use crate::repository::{HubRepository, UserRepository};
+use crate::repository::{HubRepository, UserReader, UserWriter};
 use crate::routes::{
     alert_level_to_str, get_success_and_failure_redirects, redirect, render_template,
 };

--- a/src/routes/main.rs
+++ b/src/routes/main.rs
@@ -12,7 +12,7 @@ use crate::repository::hub::DieselHubRepository;
 use crate::repository::menu::DieselMenuRepository;
 use crate::repository::role::DieselRoleRepository;
 use crate::repository::user::DieselUserRepository;
-use crate::repository::{HubRepository, MenuRepository, RoleRepository, UserRepository};
+use crate::repository::{HubRepository, MenuRepository, RoleRepository, UserReader, UserWriter};
 use crate::routes::{alert_level_to_str, redirect, render_template};
 
 #[get("/")]

--- a/tests/repository.rs
+++ b/tests/repository.rs
@@ -6,11 +6,11 @@ use pushkind_auth::domain::user::UpdateUser;
 use pushkind_auth::repository::HubRepository;
 use pushkind_auth::repository::MenuRepository;
 use pushkind_auth::repository::RoleRepository;
-use pushkind_auth::repository::UserRepository;
 use pushkind_auth::repository::hub::DieselHubRepository;
 use pushkind_auth::repository::menu::DieselMenuRepository;
 use pushkind_auth::repository::role::DieselRoleRepository;
 use pushkind_auth::repository::user::DieselUserRepository;
+use pushkind_auth::repository::{UserReader, UserWriter};
 
 mod common;
 


### PR DESCRIPTION
## Summary
- split `UserRepository` into `UserReader` and `UserWriter`
- implement the new traits for `DieselUserRepository`
- update routes, models and tests to use the new traits

## Testing
- `cargo fmt -- --check`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6877e717b5a4832fb25d20e4eb946edb