### PR TITLE
Validate redirect domain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
  "serde_html_form",
  "tera",
  "thiserror 2.0.12",
+ "url",
  "validator",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = "2.0.12"
 serde_html_form = "0.2.7"
 actix-cors = "0.7.1"
 validator = { version = "0.20.0", features = ["derive"] }
+url = "2.5.0"
 
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,11 @@ async fn main() -> std::io::Result<()> {
         }
     };
     let secret_key = Key::from(secret.as_bytes());
-    let server_config = ServerConfig { secret };
-
     let domain = env::var("DOMAIN").unwrap_or("localhost".to_string());
+    let server_config = ServerConfig {
+        secret,
+        domain: domain.clone(),
+    };
 
     let pool = match establish_connection_pool(&database_url) {
         Ok(pool) => pool,

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -2,4 +2,5 @@
 /// Basic configuration shared across handlers.
 pub struct ServerConfig {
     pub secret: String,
+    pub domain: String,
 }

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -35,8 +35,11 @@ pub async fn login(
 ) -> impl Responder {
     let repo = DieselUserRepository::new(&pool);
 
-    let (success_redirect_url, failure_redirect_url) =
-        get_success_and_failure_redirects("/auth/signin", query_params.next.as_deref());
+    let (success_redirect_url, failure_redirect_url) = get_success_and_failure_redirects(
+        "/auth/signin",
+        query_params.next.as_deref(),
+        &server_config.domain,
+    );
 
     if let Err(e) = form.validate() {
         FlashMessage::error(format!("Ошибка валидации формы: {e}")).send();
@@ -85,13 +88,17 @@ pub async fn login(
 #[post("/register")]
 pub async fn register(
     pool: web::Data<DbPool>,
+    server_config: web::Data<ServerConfig>,
     web::Form(form): web::Form<RegisterForm>,
     query_params: web::Query<AuthQueryParams>,
 ) -> impl Responder {
     let repo = DieselUserRepository::new(&pool);
 
-    let (_, failure_redirect_url) =
-        get_success_and_failure_redirects("/auth/signup", query_params.next.as_deref());
+    let (_, failure_redirect_url) = get_success_and_failure_redirects(
+        "/auth/signup",
+        query_params.next.as_deref(),
+        &server_config.domain,
+    );
 
     if let Err(e) = form.validate() {
         FlashMessage::error(format!("Ошибка валидации формы: {e}")).send();
@@ -111,9 +118,16 @@ pub async fn register(
 }
 
 #[post("/logout")]
-pub async fn logout(user: Identity, query_params: web::Query<AuthQueryParams>) -> impl Responder {
-    let (_, failure_redirect_url) =
-        get_success_and_failure_redirects("/auth/signin", query_params.next.as_deref());
+pub async fn logout(
+    user: Identity,
+    server_config: web::Data<ServerConfig>,
+    query_params: web::Query<AuthQueryParams>,
+) -> impl Responder {
+    let (_, failure_redirect_url) = get_success_and_failure_redirects(
+        "/auth/signin",
+        query_params.next.as_deref(),
+        &server_config.domain,
+    );
 
     user.logout();
     redirect(&failure_redirect_url)

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -6,6 +6,7 @@ use actix_web_flash_messages::{FlashMessage, Level};
 use lazy_static::lazy_static;
 use log::error;
 use tera::{Context, Tera};
+use url::Url;
 
 use crate::models::auth::AuthenticatedUser;
 
@@ -69,16 +70,40 @@ fn render_template(template: &str, context: &Context) -> HttpResponse {
     }))
 }
 
-fn get_success_and_failure_redirects(base_url: &str, next: Option<&str>) -> (String, String) {
-    let success_redirect_url = match next {
-        Some(s) if !s.is_empty() => s.to_string(),
-        _ => "/".to_string(),
-    };
+fn is_valid_next(next: &str, domain: &str) -> bool {
+    if next.starts_with("//") {
+        return false;
+    }
+    if let Ok(url) = Url::parse(next) {
+        match url.host_str() {
+            Some(host) => host == domain || host.ends_with(&format!(".{domain}")),
+            None => false,
+        }
+    } else {
+        true
+    }
+}
 
-    let failure_redirect_url = match next {
-        Some(s) if !s.is_empty() => format!("{base_url}?next={s}"),
-        _ => base_url.to_string(),
-    };
+fn get_success_and_failure_redirects(
+    base_url: &str,
+    next: Option<&str>,
+    domain: &str,
+) -> (String, String) {
+    let next_valid = next.and_then(|n| {
+        if !n.is_empty() && is_valid_next(n, domain) {
+            Some(n)
+        } else {
+            None
+        }
+    });
+
+    let success_redirect_url = next_valid
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "/".to_string());
+
+    let failure_redirect_url = next_valid
+        .map(|s| format!("{base_url}?next={s}"))
+        .unwrap_or_else(|| base_url.to_string());
 
     (success_redirect_url, failure_redirect_url)
 }
@@ -114,21 +139,34 @@ mod tests {
     #[test]
     fn redirects_with_next_param() {
         let (success, failure) =
-            get_success_and_failure_redirects("/auth/signin", Some("/dashboard"));
+            get_success_and_failure_redirects("/auth/signin", Some("/dashboard"), "example.com");
         assert_eq!(success, "/dashboard");
         assert_eq!(failure, "/auth/signin?next=/dashboard");
     }
 
     #[test]
     fn redirects_without_next_param() {
-        let (success, failure) = get_success_and_failure_redirects("/auth/signup", None);
+        let (success, failure) =
+            get_success_and_failure_redirects("/auth/signup", None, "example.com");
         assert_eq!(success, "/");
         assert_eq!(failure, "/auth/signup");
     }
 
     #[test]
     fn redirects_with_empty_next() {
-        let (success, failure) = get_success_and_failure_redirects("/auth/signin", Some(""));
+        let (success, failure) =
+            get_success_and_failure_redirects("/auth/signin", Some(""), "example.com");
+        assert_eq!(success, "/");
+        assert_eq!(failure, "/auth/signin");
+    }
+
+    #[test]
+    fn invalid_domain_next_defaults_to_base() {
+        let (success, failure) = get_success_and_failure_redirects(
+            "/auth/signin",
+            Some("http://evil.com"),
+            "example.com",
+        );
         assert_eq!(success, "/");
         assert_eq!(failure, "/auth/signin");
     }


### PR DESCRIPTION
## Summary
- keep success redirect relative to the configured domain
- store service domain in `ServerConfig`
- validate next parameter before using it

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6878dba23ba4832fa375f9e661a8eb3b