### PR TITLE
Ensure admin actions respect hub ownership

### DIFF
--- a/src/repository/menu.rs
+++ b/src/repository/menu.rs
@@ -48,6 +48,19 @@ impl MenuWriter for DieselMenuRepository<'_> {
 }
 
 impl MenuReader for DieselMenuRepository<'_> {
+    fn get_by_id(&self, id: i32) -> RepositoryResult<Option<Menu>> {
+        use crate::schema::menu;
+
+        let mut connection = self.pool.get()?;
+
+        let result = menu::table
+            .filter(menu::id.eq(id))
+            .first::<DbMenu>(&mut connection)
+            .optional()?;
+
+        Ok(result.map(|db_menu| db_menu.into()))
+    }
+
     fn list(&self, hub_id: i32) -> RepositoryResult<Vec<Menu>> {
         use crate::schema::menu;
 

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -117,6 +117,7 @@ pub trait RoleRepository: RoleReader + RoleWriter {}
 impl<T> RoleRepository for T where T: RoleReader + RoleWriter {}
 
 pub trait MenuReader {
+    fn get_by_id(&self, id: i32) -> RepositoryResult<Option<Menu>>;
     fn list(&self, hub_id: i32) -> RepositoryResult<Vec<Menu>>;
 }
 


### PR DESCRIPTION
## Summary
- verify hub ownership across admin endpoints
- add menu get_by_id to repository

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6895c69640ac832fa61e2d415258a1e0