### PR TITLE
Refactor admin role checks and expand tests

### DIFF
--- a/src/services/admin.rs
+++ b/src/services/admin.rs
@@ -8,26 +8,32 @@ use pushkind_common::domain::auth::AuthenticatedUser;
 use pushkind_common::routes::check_role;
 use pushkind_common::services::errors::{ServiceError, ServiceResult};
 
+/// Ensures the authenticated user has the `admin` role.
+fn ensure_admin(user: &AuthenticatedUser) -> ServiceResult<()> {
+    if !check_role("admin", &user.roles) {
+        return Err(ServiceError::Unauthorized);
+    }
+    Ok(())
+}
+
+/// Creates a new role when the current user is an admin.
 pub fn create_role(
     current_user: &AuthenticatedUser,
     new_role: &crate::domain::role::NewRole,
     repo: &impl RoleWriter,
 ) -> ServiceResult<()> {
-    if !check_role("admin", &current_user.roles) {
-        return Err(ServiceError::Unauthorized);
-    }
+    ensure_admin(current_user)?;
     repo.create_role(new_role)?;
     Ok(())
 }
 
+/// Retrieves the user and available roles for the modal editor.
 pub fn user_modal_data(
     current_user: &AuthenticatedUser,
     user_id: i32,
     repo: &(impl UserReader + RoleReader),
 ) -> ServiceResult<(Option<User>, Vec<Role>)> {
-    if !check_role("admin", &current_user.roles) {
-        return Err(ServiceError::Unauthorized);
-    }
+    ensure_admin(current_user)?;
     let user = repo
         .get_user_by_id(user_id, current_user.hub_id)?
         .map(|u| u.user);
@@ -35,14 +41,13 @@ pub fn user_modal_data(
     Ok((user, roles))
 }
 
+/// Deletes a user by ID, preventing self-deletion and non-admin access.
 pub fn delete_user_by_id(
     current_user: &AuthenticatedUser,
     user_id: i32,
     repo: &(impl UserReader + UserWriter),
 ) -> ServiceResult<()> {
-    if !check_role("admin", &current_user.roles) {
-        return Err(ServiceError::Unauthorized);
-    }
+    ensure_admin(current_user)?;
 
     let current_user_id: i32 = current_user
         .sub
@@ -61,6 +66,7 @@ pub fn delete_user_by_id(
     Ok(())
 }
 
+/// Assigns roles and updates a user if they belong to the current hub.
 pub fn assign_roles_and_update_user(
     current_user: &AuthenticatedUser,
     user_id: i32,
@@ -68,9 +74,7 @@ pub fn assign_roles_and_update_user(
     role_ids: &[i32],
     repo: &(impl UserWriter + UserReader),
 ) -> ServiceResult<()> {
-    if !check_role("admin", &current_user.roles) {
-        return Err(ServiceError::Unauthorized);
-    }
+    ensure_admin(current_user)?;
     // Validate user exists in the hub
     let user = match repo.get_user_by_id(user_id, current_user.hub_id)? {
         Some(u) => u.user,
@@ -81,26 +85,24 @@ pub fn assign_roles_and_update_user(
     Ok(())
 }
 
+/// Creates a new hub when invoked by an admin.
 pub fn create_hub(
     current_user: &AuthenticatedUser,
     new_hub: &NewHub,
     repo: &impl HubWriter,
 ) -> ServiceResult<()> {
-    if !check_role("admin", &current_user.roles) {
-        return Err(ServiceError::Unauthorized);
-    }
+    ensure_admin(current_user)?;
     repo.create_hub(new_hub)?;
     Ok(())
 }
 
+/// Deletes a role by ID, protecting the base admin role.
 pub fn delete_role_by_id(
     current_user: &AuthenticatedUser,
     role_id: i32,
     repo: &impl RoleWriter,
 ) -> ServiceResult<()> {
-    if !check_role("admin", &current_user.roles) {
-        return Err(ServiceError::Unauthorized);
-    }
+    ensure_admin(current_user)?;
     if role_id == 1 {
         // Protect the base admin role from deletion.
         return Err(ServiceError::Unauthorized);
@@ -109,14 +111,13 @@ pub fn delete_role_by_id(
     Ok(())
 }
 
+/// Deletes a hub by ID, preventing removal of the current user's hub.
 pub fn delete_hub_by_id(
     current_user: &AuthenticatedUser,
     hub_id: i32,
     repo: &impl HubWriter,
 ) -> ServiceResult<()> {
-    if !check_role("admin", &current_user.roles) {
-        return Err(ServiceError::Unauthorized);
-    }
+    ensure_admin(current_user)?;
     if current_user.hub_id == hub_id {
         // Prevent deleting the hub currently associated with the user.
         return Err(ServiceError::Unauthorized);
@@ -125,26 +126,24 @@ pub fn delete_hub_by_id(
     Ok(())
 }
 
+/// Creates a new menu entry for the given hub.
 pub fn create_menu(
     current_user: &AuthenticatedUser,
     new_menu: &crate::domain::menu::NewMenu,
     repo: &impl MenuWriter,
 ) -> ServiceResult<()> {
-    if !check_role("admin", &current_user.roles) {
-        return Err(ServiceError::Unauthorized);
-    }
+    ensure_admin(current_user)?;
     repo.create_menu(new_menu)?;
     Ok(())
 }
 
+/// Deletes a menu by ID if it exists for the current hub.
 pub fn delete_menu_by_id(
     current_user: &AuthenticatedUser,
     menu_id: i32,
     repo: &(impl MenuReader + MenuWriter),
 ) -> ServiceResult<()> {
-    if !check_role("admin", &current_user.roles) {
-        return Err(ServiceError::Unauthorized);
-    }
+    ensure_admin(current_user)?;
     let menu = match repo.get_menu_by_id(menu_id, current_user.hub_id)? {
         Some(m) => m,
         None => return Ok(()),
@@ -156,45 +155,168 @@ pub fn delete_menu_by_id(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::role::Role;
-    use crate::domain::user::{User, UserWithRoles};
+    use crate::domain::hub::NewHub;
+    use crate::domain::menu::{Menu, NewMenu};
+    use crate::domain::role::{NewRole, Role};
+    use crate::domain::user::UpdateUser;
     use crate::repository::test::TestRepository;
+    use pushkind_common::domain::auth::AuthenticatedUser;
 
-    #[test]
-    fn test_user_modal_data() {
-        use pushkind_common::domain::auth::AuthenticatedUser;
-        let now = TestRepository::now();
-        let user = User {
-            id: 7,
-            email: "u@e".into(),
-            name: Some("U".into()),
-            hub_id: 10,
-            password_hash: "".into(),
-            created_at: now,
-            updated_at: now,
-            roles: vec![],
-        };
-        let repo = TestRepository::with_users(vec![UserWithRoles {
-            user,
-            roles: vec![],
-        }])
-        .with_roles(vec![Role {
-            id: 1,
-            name: "admin".into(),
-            created_at: now,
-            updated_at: now,
-        }])
-        .with_menus(vec![]);
-        let current_user = AuthenticatedUser {
+    fn admin_user() -> AuthenticatedUser {
+        AuthenticatedUser {
             sub: "1".into(),
             email: "a@b".into(),
-            hub_id: 10,
+            hub_id: 1,
             name: "Admin".into(),
             roles: vec!["admin".into()],
             exp: 0,
-        };
+        }
+    }
+
+    fn regular_user() -> AuthenticatedUser {
+        AuthenticatedUser {
+            sub: "2".into(),
+            email: "u@e".into(),
+            hub_id: 1,
+            name: "User".into(),
+            roles: vec!["user".into()],
+            exp: 0,
+        }
+    }
+
+    #[test]
+    fn user_modal_data_success_and_not_found() {
+        let now = TestRepository::now();
+        let repo = TestRepository::with_users(vec![TestRepository::make_user(7, "u@e", 1, vec![])])
+            .with_roles(vec![Role {
+                id: 1,
+                name: "admin".into(),
+                created_at: now,
+                updated_at: now,
+            }]);
+        let current_user = admin_user();
         let (user, roles) = user_modal_data(&current_user, 7, &repo).unwrap();
         assert!(user.is_some());
         assert_eq!(roles.len(), 1);
+
+        let (missing, _) = user_modal_data(&current_user, 99, &repo).unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[test]
+    fn user_modal_data_unauthorized() {
+        let repo = TestRepository::new();
+        let res = user_modal_data(&regular_user(), 1, &repo);
+        assert!(matches!(res, Err(ServiceError::Unauthorized)));
+    }
+
+    #[test]
+    fn create_role_authorization() {
+        let repo = TestRepository::new();
+        let new_role = NewRole { name: "new".into() };
+        assert!(create_role(&admin_user(), &new_role, &repo).is_ok());
+        assert!(matches!(
+            create_role(&regular_user(), &new_role, &repo),
+            Err(ServiceError::Unauthorized)
+        ));
+    }
+
+    #[test]
+    fn delete_user_by_id_paths() {
+        let repo = TestRepository::with_users(vec![TestRepository::make_user(2, "u@e", 1, vec![])]);
+        assert!(delete_user_by_id(&admin_user(), 2, &repo).is_ok());
+        let mut admin_self = admin_user();
+        admin_self.sub = "2".into();
+        assert!(matches!(
+            delete_user_by_id(&admin_self, 2, &repo),
+            Err(ServiceError::Unauthorized)
+        ));
+        assert!(matches!(
+            delete_user_by_id(&admin_user(), 99, &repo),
+            Err(ServiceError::NotFound)
+        ));
+        assert!(matches!(
+            delete_user_by_id(&regular_user(), 2, &repo),
+            Err(ServiceError::Unauthorized)
+        ));
+    }
+
+    #[test]
+    fn assign_roles_and_update_user_cases() {
+        let repo = TestRepository::with_users(vec![TestRepository::make_user(2, "u@e", 1, vec![])]);
+        let updates = UpdateUser {
+            name: "New".into(),
+            password: None,
+            roles: None,
+        };
+        assert!(assign_roles_and_update_user(&admin_user(), 2, &updates, &[1, 2], &repo).is_ok());
+        assert!(assign_roles_and_update_user(&admin_user(), 99, &updates, &[], &repo).is_ok());
+        assert!(matches!(
+            assign_roles_and_update_user(&regular_user(), 2, &updates, &[], &repo),
+            Err(ServiceError::Unauthorized)
+        ));
+    }
+
+    #[test]
+    fn create_and_delete_hub() {
+        let repo = TestRepository::new();
+        let new_hub = NewHub { name: "hub".into() };
+        assert!(create_hub(&admin_user(), &new_hub, &repo).is_ok());
+        assert!(matches!(
+            create_hub(&regular_user(), &new_hub, &repo),
+            Err(ServiceError::Unauthorized)
+        ));
+        assert!(delete_hub_by_id(&admin_user(), 2, &repo).is_ok());
+        assert!(matches!(
+            delete_hub_by_id(&admin_user(), 1, &repo),
+            Err(ServiceError::Unauthorized)
+        ));
+        assert!(matches!(
+            delete_hub_by_id(&regular_user(), 2, &repo),
+            Err(ServiceError::Unauthorized)
+        ));
+    }
+
+    #[test]
+    fn delete_role_by_id_paths() {
+        let repo = TestRepository::new();
+        assert!(delete_role_by_id(&admin_user(), 2, &repo).is_ok());
+        assert!(matches!(
+            delete_role_by_id(&admin_user(), 1, &repo),
+            Err(ServiceError::Unauthorized)
+        ));
+        assert!(matches!(
+            delete_role_by_id(&regular_user(), 2, &repo),
+            Err(ServiceError::Unauthorized)
+        ));
+    }
+
+    #[test]
+    fn create_and_delete_menu() {
+        let repo = TestRepository::new();
+        let new_menu = NewMenu {
+            name: "m".into(),
+            url: "/".into(),
+            hub_id: 1,
+        };
+        assert!(create_menu(&admin_user(), &new_menu, &repo).is_ok());
+        assert!(matches!(
+            create_menu(&regular_user(), &new_menu, &repo),
+            Err(ServiceError::Unauthorized)
+        ));
+
+        let menu = Menu {
+            id: 1,
+            name: "m".into(),
+            url: "/".into(),
+            hub_id: 1,
+        };
+        let repo_with_menu = TestRepository::new().with_menus(vec![menu]);
+        assert!(delete_menu_by_id(&admin_user(), 1, &repo_with_menu).is_ok());
+        assert!(delete_menu_by_id(&admin_user(), 99, &repo).is_ok());
+        assert!(matches!(
+            delete_menu_by_id(&regular_user(), 1, &repo),
+            Err(ServiceError::Unauthorized)
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- add `ensure_admin` helper to de-duplicate role checks
- document and clean up admin service functions
- add unit tests for admin flows and edge cases

## Testing
- `cargo build --verbose` *(fails: compilation interrupted)*
- `cargo test --verbose` *(fails: compilation interrupted)*
- `cargo clippy --tests -- -Dwarnings` *(fails: compilation interrupted)*
- `cargo fmt -- --check`

------
https://chatgpt.com/codex/tasks/task_e_68c03e3e5264832a8443d5b9f9bbf7b2