### PR TITLE
Add auth service docs and tests for edge cases

### DIFF
--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -17,9 +17,9 @@ use crate::domain::user::{NewUser, UpdateUser, User};
 pub mod hub;
 pub mod menu;
 pub mod role;
-pub mod user;
 #[cfg(test)]
 pub mod test;
+pub mod user;
 
 #[derive(Clone)]
 pub struct DieselRepository {
@@ -96,10 +96,11 @@ pub trait UserReader {
     ) -> RepositoryResult<Option<UserWithRoles>> {
         let email = email.to_lowercase();
         let user = self.get_user_by_email(&email, hub_id)?;
-        if let Some(ur) = user
-            && self.verify_password(password, &ur.user.password_hash) {
+        if let Some(ur) = user {
+            if self.verify_password(password, &ur.user.password_hash) {
                 return Ok(Some(ur));
             }
+        }
         Ok(None)
     }
     fn get_roles(&self, user_id: i32) -> RepositoryResult<Vec<Role>>;


### PR DESCRIPTION
## Summary
- document login_user, register_user, and list_hubs APIs
- add unit tests for hub listing, login failures, and registration error paths
- simplify repository login to use stable syntax

## Testing
- `cargo fmt -- --check`
- `cargo clippy --tests -- -Dwarnings`
- `cargo build --verbose`
- `cargo test --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68c06b3c5528832a9919a48ed86f38a0