### PR TITLE
docs: document service modules

### DIFF
--- a/src/services/admin.rs
+++ b/src/services/admin.rs
@@ -1,3 +1,5 @@
+//! Administrative services for managing users, roles, menus, and hubs.
+
 use crate::domain::hub::NewHub;
 use crate::domain::role::Role;
 use crate::domain::user::{UpdateUser, User};

--- a/src/services/api.rs
+++ b/src/services/api.rs
@@ -1,3 +1,5 @@
+//! API services for retrieving and listing users.
+
 use pushkind_common::domain::auth::AuthenticatedUser;
 use pushkind_common::pagination::DEFAULT_ITEMS_PER_PAGE;
 use pushkind_common::services::errors::ServiceResult;
@@ -69,7 +71,14 @@ mod tests {
     #[test]
     fn get_user_by_optional_id_none_returns_current() {
         let repo = sample_repo();
-        let current = AuthenticatedUser { sub: "42".into(), email: "me@hub".into(), hub_id: 10, name: "Me".into(), roles: vec![], exp: 0 };
+        let current = AuthenticatedUser {
+            sub: "42".into(),
+            email: "me@hub".into(),
+            hub_id: 10,
+            name: "Me".into(),
+            roles: vec![],
+            exp: 0,
+        };
         let res = get_user_by_optional_id(None, current, &repo).unwrap();
         assert_eq!(res.unwrap().email, "me@hub");
     }
@@ -77,7 +86,14 @@ mod tests {
     #[test]
     fn get_user_by_optional_id_some_found() {
         let repo = sample_repo();
-        let current = AuthenticatedUser { sub: "1".into(), email: "user1@example.com".into(), hub_id: 10, name: "User1".into(), roles: vec![], exp: 0 };
+        let current = AuthenticatedUser {
+            sub: "1".into(),
+            email: "user1@example.com".into(),
+            hub_id: 10,
+            name: "User1".into(),
+            roles: vec![],
+            exp: 0,
+        };
         let res = get_user_by_optional_id(Some(1), current, &repo).unwrap();
         assert_eq!(res.unwrap().sub, "1");
     }
@@ -85,7 +101,14 @@ mod tests {
     #[test]
     fn get_user_by_optional_id_some_not_found() {
         let repo = sample_repo();
-        let current = AuthenticatedUser { sub: "1".into(), email: "user1@example.com".into(), hub_id: 10, name: "User1".into(), roles: vec![], exp: 0 };
+        let current = AuthenticatedUser {
+            sub: "1".into(),
+            email: "user1@example.com".into(),
+            hub_id: 10,
+            name: "User1".into(),
+            roles: vec![],
+            exp: 0,
+        };
         let res = get_user_by_optional_id(Some(999), current, &repo).unwrap();
         assert!(res.is_none());
     }
@@ -111,6 +134,5 @@ mod tests {
         let out = list_users(Some("member".into()), None, Some(1), 10, &repo).unwrap();
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].email, "user2@example.com");
-        
     }
 }

--- a/src/services/auth.rs
+++ b/src/services/auth.rs
@@ -1,3 +1,5 @@
+//! Authentication services for logging in users, registering new accounts, and listing hubs.
+
 use pushkind_common::domain::auth::AuthenticatedUser;
 use pushkind_common::services::errors::{ServiceError, ServiceResult};
 

--- a/src/services/main.rs
+++ b/src/services/main.rs
@@ -1,3 +1,5 @@
+//! Services powering the main application views, such as loading index data and updating users.
+
 use crate::domain::hub::Hub;
 use crate::domain::menu::Menu;
 use crate::domain::role::Role;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,11 @@
+//! Core service layer containing business logic used by routes.
+//!
+//! Submodules:
+//! - [`admin`]: administrative operations.
+//! - [`api`]: API-facing utilities.
+//! - [`auth`]: authentication workflows.
+//! - [`main`]: main application view helpers.
+
 pub mod admin;
 pub mod api;
 pub mod auth;


### PR DESCRIPTION
## Summary
- document purpose of `services` layer and reference submodules
- add module-level docs for `admin`, `api`, `auth`, and `main` services

## Testing
- `cargo fmt -- --check src/services/admin.rs src/services/api.rs src/services/auth.rs src/services/main.rs src/services/mod.rs`
- `cargo clippy --tests -- -Dwarnings`
- `cargo build --verbose` *(fails: terminated due to timeout)*
- `cargo test --verbose` *(fails: terminated due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68c078289e5c832aaa2c8817af71cb5f