### PR TITLE
Dev: validate user existence when reissuing session token

### DIFF
--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -96,10 +96,11 @@ pub trait UserReader {
     ) -> RepositoryResult<Option<UserWithRoles>> {
         let email = email.to_lowercase();
         let user = self.get_user_by_email(&email, hub_id)?;
-        if let Some(ur) = user
-            && self.verify_password(password, &ur.user.password_hash) {
+        if let Some(ur) = user {
+            if self.verify_password(password, &ur.user.password_hash) {
                 return Ok(Some(ur));
             }
+        }
         Ok(None)
     }
     fn get_roles(&self, user_id: i32) -> RepositoryResult<Vec<Role>>;

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -34,6 +34,7 @@ struct LoginTokenParams {
 #[get("/login")]
 pub async fn login_token(
     request: HttpRequest,
+    repo: web::Data<DieselRepository>,
     common_config: web::Data<CommonServerConfig>,
     query_params: web::Query<LoginTokenParams>,
 ) -> impl Responder {
@@ -41,6 +42,7 @@ pub async fn login_token(
         &query_params.token,
         &common_config.secret,
         7,
+        repo.get_ref(),
     ) {
         Ok(jwt) => jwt,
         Err(e) => {


### PR DESCRIPTION
## Summary
- ensure `/auth/login` revalidates user against repository before issuing a new session token
- add tests for token reissue success and missing-user failure
- simplify repository `login` helper to stable pattern

## Testing
- `cargo fmt -- --check`
- `cargo clippy --tests -- -Dwarnings`
- `cargo build --verbose` *(terminated early due to environment constraints)*
- `cargo test --verbose` *(terminated early due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68c16883eb24832aa7bcec966b8a3fd0