### PR TITLE
Dev: surface not-found error when editing missing user

### DIFF
--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -96,10 +96,11 @@ pub trait UserReader {
     ) -> RepositoryResult<Option<UserWithRoles>> {
         let email = email.to_lowercase();
         let user = self.get_user_by_email(&email, hub_id)?;
-        if let Some(ur) = user
-            && self.verify_password(password, &ur.user.password_hash) {
+        if let Some(ur) = user {
+            if self.verify_password(password, &ur.user.password_hash) {
                 return Ok(Some(ur));
             }
+        }
         Ok(None)
     }
     fn get_roles(&self, user_id: i32) -> RepositoryResult<Vec<Role>>;

--- a/src/services/admin.rs
+++ b/src/services/admin.rs
@@ -80,7 +80,7 @@ pub fn assign_roles_and_update_user(
     // Validate user exists in the hub
     let user = match repo.get_user_by_id(user_id, current_user.hub_id)? {
         Some(u) => u.user,
-        None => return Ok(()),
+        None => return Err(ServiceError::NotFound),
     };
     repo.assign_roles_to_user(user_id, role_ids)?;
     repo.update_user(user.id, user.hub_id, updates)?;
@@ -252,7 +252,10 @@ mod tests {
             roles: None,
         };
         assert!(assign_roles_and_update_user(&admin_user(), 2, &updates, &[1, 2], &repo).is_ok());
-        assert!(assign_roles_and_update_user(&admin_user(), 99, &updates, &[], &repo).is_ok());
+        assert!(matches!(
+            assign_roles_and_update_user(&admin_user(), 99, &updates, &[], &repo),
+            Err(ServiceError::NotFound)
+        ));
         assert!(matches!(
             assign_roles_and_update_user(&regular_user(), 2, &updates, &[], &repo),
             Err(ServiceError::Unauthorized)


### PR DESCRIPTION
## Summary
- return `ServiceError::NotFound` when assigning roles to a user that doesn't exist
- update admin service test to expect `NotFound`
- format repository login helper to avoid unstable `if let` chain

## Testing
- `cargo fmt -- --check`
- `cargo clippy --tests -- -Dwarnings`
- `cargo build --verbose` *(fails: terminated early due to environment constraints)*
- `cargo test --verbose` *(fails: output exceeded limit / terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c16d748cc0832a98512b36ca81a0b3